### PR TITLE
implemented endpoint to edit module and return updated response

### DIFF
--- a/src/module/dtos/module.dto.ts
+++ b/src/module/dtos/module.dto.ts
@@ -1,5 +1,6 @@
-import { IsString, IsNotEmpty } from 'class-validator';
+import { IsString, IsNotEmpty, ValidateNested } from 'class-validator';
 import { ContentResponseDto } from '../../content/dtos/content.dto';
+import { Type } from 'class-transformer';
 
 export class ModuleResponseDto {
   @IsString()
@@ -29,4 +30,30 @@ export class ModuleCardResponseDto {
   @IsString()
   @IsNotEmpty()
   age_group: string;
+}
+
+export class ModuleFullResponseDto {
+  @IsString()
+  @IsNotEmpty()
+  module_id: string;
+
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+
+  @IsString()
+  @IsNotEmpty()
+  synopsis: string;
+
+  @IsString()
+  @IsNotEmpty()
+  thumbnail: string;
+
+  @IsString()
+  @IsNotEmpty()
+  age_group: string;
+
+  @ValidateNested({ each: true })
+  @Type(() => ContentResponseDto)
+  contents: ContentResponseDto[];
 }

--- a/src/module/module.controller.ts
+++ b/src/module/module.controller.ts
@@ -7,9 +7,14 @@ import {
   Param,
   Query,
   UnauthorizedException,
+  Put,
 } from '@nestjs/common';
 import { ModuleService } from './module.service';
-import { ModuleCardResponseDto, ModuleResponseDto } from './dtos/module.dto';
+import {
+  ModuleCardResponseDto,
+  ModuleFullResponseDto,
+  ModuleResponseDto,
+} from './dtos/module.dto';
 
 @Controller('module')
 export class ModuleController {
@@ -54,5 +59,14 @@ export class ModuleController {
     @Query('keyword') keyword: string,
   ): Promise<ModuleCardResponseDto[]> {
     return await this.moduleService.searchModuleByKeyword(keyword);
+  }
+
+  @Put('/id/:id')
+  async updateModule(
+    @Param('id') id: string,
+    @Body() updateModuleDto: Partial<Omit<ModuleFullResponseDto, 'module_id'>>,
+    @Headers('x-user-id') userId: string,
+  ): Promise<ModuleFullResponseDto> {
+    return await this.moduleService.updateModule(id, updateModuleDto, userId);
   }
 }

--- a/src/module/module.service.ts
+++ b/src/module/module.service.ts
@@ -1,5 +1,14 @@
-import { Injectable, BadRequestException } from '@nestjs/common';
-import { ModuleCardResponseDto, ModuleResponseDto } from './dtos/module.dto';
+import {
+  Injectable,
+  BadRequestException,
+  UnauthorizedException,
+  NotFoundException,
+} from '@nestjs/common';
+import {
+  ModuleCardResponseDto,
+  ModuleFullResponseDto,
+  ModuleResponseDto,
+} from './dtos/module.dto';
 import { PrismaService } from '../prisma/prisma.service';
 
 interface RandomModuleResult {
@@ -150,5 +159,81 @@ export class ModuleService {
       age_group: module.age_group,
     }));
     return moduleCards;
+  }
+
+  async updateModule(
+    moduleId: string,
+    updateModuleDto: Partial<Omit<ModuleFullResponseDto, 'module_id'>>,
+    userId: string,
+  ): Promise<ModuleFullResponseDto> {
+    const user = await this.prisma.user.findUnique({
+      where: { user_id: userId },
+    });
+
+    if (!user) {
+      throw new UnauthorizedException(`User with ID ${userId} does not exist`);
+    }
+
+    if (user.user_type !== 'admin') {
+      throw new UnauthorizedException(`User ${userId} is not authorized`);
+    }
+
+    const existingModule = await this.prisma.module.findUnique({
+      where: { module_id: moduleId },
+    });
+
+    if (!existingModule) {
+      throw new NotFoundException(`Module with ID ${moduleId} not found`);
+    }
+
+    await this.prisma.module.update({
+      where: { module_id: moduleId },
+      data: {
+        title: updateModuleDto.title ?? existingModule.title,
+        synopsis: updateModuleDto.synopsis ?? existingModule.synopsis,
+        thumbnail: updateModuleDto.thumbnail ?? existingModule.thumbnail,
+        age_group: updateModuleDto.age_group ?? existingModule.age_group,
+      },
+    });
+
+    if (updateModuleDto.contents && updateModuleDto.contents.length > 0) {
+      for (const contentDto of updateModuleDto.contents) {
+        await this.prisma.content.update({
+          where: { content_id: contentDto.content_id },
+          data: {
+            text: contentDto.text,
+            image: contentDto.image,
+            template: contentDto.template,
+            video_link: contentDto.video_link,
+          },
+        });
+      }
+    }
+
+    const finalModule = await this.prisma.module.findUnique({
+      where: { module_id: moduleId },
+      include: { contents: true },
+    });
+
+    if (!finalModule) {
+      throw new NotFoundException(
+        `Module with ID ${moduleId} not found after update`,
+      );
+    }
+    return {
+      module_id: finalModule.module_id,
+      title: finalModule.title,
+      synopsis: finalModule.synopsis,
+      thumbnail: finalModule.thumbnail,
+      age_group: finalModule.age_group,
+      contents: finalModule.contents.map((content) => ({
+        content_id: content.content_id,
+        text: content.text ?? '',
+        image: content.image ?? '',
+        template: content.template ?? '',
+        video_link: content.video_link ?? '',
+        module_id: content.module_id,
+      })),
+    };
   }
 }

--- a/src/module/module.service.ts
+++ b/src/module/module.service.ts
@@ -186,47 +186,52 @@ export class ModuleService {
       throw new NotFoundException(`Module with ID ${moduleId} not found`);
     }
 
-    await this.prisma.module.update({
-      where: { module_id: moduleId },
-      data: {
-        title: updateModuleDto.title ?? existingModule.title,
-        synopsis: updateModuleDto.synopsis ?? existingModule.synopsis,
-        thumbnail: updateModuleDto.thumbnail ?? existingModule.thumbnail,
-        age_group: updateModuleDto.age_group ?? existingModule.age_group,
-      },
-    });
+    const result = await this.prisma.$transaction(async (tx) => {
+      await tx.module.update({
+        where: { module_id: moduleId },
+        data: {
+          title: updateModuleDto.title ?? existingModule.title,
+          synopsis: updateModuleDto.synopsis ?? existingModule.synopsis,
+          thumbnail: updateModuleDto.thumbnail ?? existingModule.thumbnail,
+          age_group: updateModuleDto.age_group ?? existingModule.age_group,
+        },
+      });
 
-    if (updateModuleDto.contents && updateModuleDto.contents.length > 0) {
-      for (const contentDto of updateModuleDto.contents) {
-        await this.prisma.content.update({
-          where: { content_id: contentDto.content_id },
-          data: {
-            text: contentDto.text,
-            image: contentDto.image,
-            template: contentDto.template,
-            video_link: contentDto.video_link,
-          },
-        });
+      if (updateModuleDto.contents && updateModuleDto.contents.length > 0) {
+        const contentUpdates = updateModuleDto.contents.map((contentDto) =>
+          tx.content.update({
+            where: { content_id: contentDto.content_id },
+            data: {
+              text: contentDto.text,
+              image: contentDto.image,
+              template: contentDto.template,
+              video_link: contentDto.video_link,
+            },
+          }),
+        );
+
+        await Promise.all(contentUpdates);
       }
-    }
 
-    const finalModule = await this.prisma.module.findUnique({
-      where: { module_id: moduleId },
-      include: { contents: true },
+      return await tx.module.findUnique({
+        where: { module_id: moduleId },
+        include: { contents: true },
+      });
     });
 
-    if (!finalModule) {
+    if (!result) {
       throw new NotFoundException(
         `Module with ID ${moduleId} not found after update`,
       );
     }
+
     return {
-      module_id: finalModule.module_id,
-      title: finalModule.title,
-      synopsis: finalModule.synopsis,
-      thumbnail: finalModule.thumbnail,
-      age_group: finalModule.age_group,
-      contents: finalModule.contents.map((content) => ({
+      module_id: result.module_id,
+      title: result.title,
+      synopsis: result.synopsis,
+      thumbnail: result.thumbnail,
+      age_group: result.age_group,
+      contents: result.contents.map((content) => ({
         content_id: content.content_id,
         text: content.text ?? '',
         image: content.image ?? '',


### PR DESCRIPTION
This commit introduces an endpoint to update an existing module by its ID.

Controller

Added PUT /id/:id endpoint to handle module updates.

Accepts partial ModuleFullResponseDto (excluding module_id) in the request body.

Requires x-user-id header for authentication/authorization.

Service

Validates the requesting user exists and is an admin.

Ensures the module exists before updating.

Updates module fields (title, sinopsys, thumbnail, age_group) with provided values or keeps existing ones.

Iterates over contents, updating their data (text, image, template, video_link).

Returns the full updated module with all its contents.

DTOs

Uses ModuleFullResponseDto to enforce response structure.

Ensures nested validation for contents.